### PR TITLE
Fix deprecated async_forward_entry_setup

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -59,13 +59,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     # Setup platforms (based on the list of entity types in PLATFORMS defined above)
     # This calls the async_setup method in each of your entity type files.
     for platform in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(config_entry, platform)
-        )
+        await hass.config_entries.async_forward_entry_setups(config_entry, [platform])
 
     # Return true to denote a successful setup.
     return True
-
 
 async def _async_update_listener(hass: HomeAssistant, config_entry):
     """Handle config options update."""


### PR DESCRIPTION
async_forward_entry_setup was deprecated for async_forward_entry_setups instead. This seems to work fine for me and I now have data. 